### PR TITLE
Adding a feature to have a non-selectable heading to the ui-list

### DIFF
--- a/jquery.mentions.coffee
+++ b/jquery.mentions.coffee
@@ -85,8 +85,8 @@ $.widget( "ui.areacomplete", $.ui.autocomplete,
 
     _renderItem: (ul, item) ->
         li = $('<li>')
-        if not item.value
-            li.append(item[0]);
+        if item.is_header
+            li.append(item.value);
             li.addClass('ui-list-header');
         else
             anchor = $('<a>').appendTo(li)

--- a/jquery.mentions.coffee
+++ b/jquery.mentions.coffee
@@ -85,11 +85,15 @@ $.widget( "ui.areacomplete", $.ui.autocomplete,
 
     _renderItem: (ul, item) ->
         li = $('<li>')
-        anchor = $('<a>').appendTo(li)
-        if item.image
-            anchor.append("<img src=\"#{item.image}\" />")
-        value = item.value.replace(this.searchTerm.substring(), "<strong>$&</strong>")
-        anchor.append(value)
+        if not item.value
+            li.append(item[0]);
+            li.addClass('ui-list-header');
+        else
+            anchor = $('<a>').appendTo(li)
+            if item.image
+                anchor.append("<img src=\"#{item.image}\" />")
+            value = item.value.replace(this.searchTerm.substring(), "<strong>$&</strong>")
+            anchor.append(value)
         return li.appendTo(ul)
 )
 

--- a/jquery.mentions.css
+++ b/jquery.mentions.css
@@ -32,3 +32,8 @@
   background-color: #a3bcea;
   filter: progid:DXImageTransform.Microsoft.Alpha(opacity=0);
 }
+
+.ui-autocomplete .ui-list-header{
+  padding: 10px;
+  font-weight: bold;
+}

--- a/jquery.mentions.js
+++ b/jquery.mentions.js
@@ -105,8 +105,8 @@
     _renderItem: function(ul, item) {
       var anchor, li, value;
       li = $('<li>');
-      if(!item.value){
-        li.append(item[0]);
+      if(item.is_header){
+        li.append(item.value);
         li.addClass('ui-list-header');
       }else{
         anchor = $('<a>').appendTo(li);

--- a/jquery.mentions.js
+++ b/jquery.mentions.js
@@ -105,12 +105,17 @@
     _renderItem: function(ul, item) {
       var anchor, li, value;
       li = $('<li>');
-      anchor = $('<a>').appendTo(li);
-      if (item.image) {
-        anchor.append("<img src=\"" + item.image + "\" />");
+      if(!item.value){
+        li.append(item[0]);
+        li.addClass('ui-list-header');
+      }else{
+        anchor = $('<a>').appendTo(li);
+        if (item.image) {
+          anchor.append("<img src=\"" + item.image + "\" />");
+        }
+        value = item.value.replace(this.searchTerm.substring(), "<strong>$&</strong>");
+        anchor.append(value);
       }
-      value = item.value.replace(this.searchTerm.substring(), "<strong>$&</strong>");
-      anchor.append(value);
       return li.appendTo(ul);
     }
   });


### PR DESCRIPTION
Modified the code to allow to have a heading for the UI list, to sub-categorize the list.

Example : 
Response : 
[{value:"I'm Following", is_header: true},{"uid":1,"value":"User1"},{"uid":2,"value":"User2"},{"uid":3,"value":"User3"},{value:"Other users", is_header: true},{"uid":4,"value":"User4"},{"uid":5,"value":"User5"}]

UI list will look like 
![follow](https://cloud.githubusercontent.com/assets/146154/6591726/e61ea8ce-c7e9-11e4-835c-111eadaf0180.png)
