### PR TITLE
Bugfix: when add the same mention more than once position is not correct

### DIFF
--- a/jquery.mentions.coffee
+++ b/jquery.mentions.coffee
@@ -211,6 +211,7 @@ class MentionsInput extends MentionsBase
             @input.on("resize.#{namespace}", (=> setTimeout(@_updateVScroll, 10)))
 
     _setValue: (value) ->
+        offset = 0
         mentionRE = /@\[([^\]]+)\]\(([^ \)]+)\)/g
         @value = value.replace(mentionRE, '$1')
         @input.val(@value)
@@ -220,8 +221,9 @@ class MentionsInput extends MentionsBase
             @_addMention(
                 name: match[1],
                 uid: match[2],
-                pos: @value.indexOf(match[1])
+                pos: match.index - offset
             )
+            offset += match[2].length + 5
             match = mentionRE.exec(value)
         @_updateValue()
 

--- a/jquery.mentions.js
+++ b/jquery.mentions.js
@@ -270,7 +270,8 @@
     };
 
     MentionsInput.prototype._setValue = function(value) {
-      var match, mentionRE;
+      var match, mentionRE, offset;
+      offset = 0;
       mentionRE = /@\[([^\]]+)\]\(([^ \)]+)\)/g;
       this.value = value.replace(mentionRE, '$1');
       this.input.val(this.value);
@@ -279,8 +280,9 @@
         this._addMention({
           name: match[1],
           uid: match[2],
-          pos: this.value.indexOf(match[1])
+          pos: match.index - offset
         });
+        offset += match[2].length + 5;
         match = mentionRE.exec(value);
       }
       return this._updateValue();


### PR DESCRIPTION
When you add some mention more than once, the position of all mentions except the first is incorrect. The reason is that every time *indexOf()* return the first occurrence of the mention. We can calculate the position, using position into formated text and length of all additional data used in previous mentions (5 special characters - `@[]()` and length of the *uid*).