### PR TITLE
Bugfix: deleting mentions, when they are more than one, lead to inconsistencies

### DIFF
--- a/jquery.mentions.coffee
+++ b/jquery.mentions.coffee
@@ -272,7 +272,7 @@ class MentionsInput extends MentionsBase
             if not change.removed
                 cursor += change.count
 
-        for mention, i in @mentions[..]
+        for mention, i in @mentions[..] by -1
             piece = value.substring(mention.pos, mention.pos + mention.name.length)
             if mention.name != piece
                 @mentions.splice(i, 1)

--- a/jquery.mentions.js
+++ b/jquery.mentions.js
@@ -359,7 +359,7 @@
         }
       }
       _ref = this.mentions.slice(0);
-      for (i = _j = 0, _len1 = _ref.length; _j < _len1; i = ++_j) {
+      for (i = _j = _ref.length - 1; _j >= 0; i = _j += -1) {
         mention = _ref[i];
         piece = value.substring(mention.pos, mention.pos + mention.name.length);
         if (mention.name !== piece) {


### PR DESCRIPTION
You can reproduce the bug when you delete two or more mentions simultaneously or by deleting all text (with more than one mention).
The problem comes from the loop over the `@mentions` array that removes the unnecessary mentions. Compiled version of the loop iterates over the copy of `@mentions`. When we remove the mentions with index 0, the second iteration tries to remove mention with index 1, but this mention is already at he position 0 in `@mentions` array. As a consequence, this mentions will never be removed but instead someone else may be deleted.
This problem can easily be circumvented by crawl array backwards.