### PR TITLE
Automatically add a space after inserting mention

### DIFF
--- a/jquery.mentions.coffee
+++ b/jquery.mentions.coffee
@@ -44,7 +44,7 @@ $.widget( "ui.areacomplete", $.ui.autocomplete,
         value = @_value()
         before = value.substring(0, @start)
         after = value.substring(@end)
-        newval = ui.item.value
+        newval = ui.item.value + ' '
         value = before + newval + after
         @_value(value)
         Selection.set(@element, before.length + newval.length)


### PR DESCRIPTION
- Resolves #46
- user experience change
- will automatically add a space after inserting a mention so that the end user doesn't have to
- mentions on github and other places does this

After accepting this PR, please generate .js file and commit to keep in sync.